### PR TITLE
Feat:Add Taranis X9D

### DIFF
--- a/src/skybrush_ext_rc_gamepad/supported_devices.json
+++ b/src/skybrush_ext_rc_gamepad/supported_devices.json
@@ -402,6 +402,69 @@
           "signed": true
         }
       ]
+    },
+    {
+      "match": [
+        {
+          "vid": "0x1209",
+          "pid": "0x4F54",
+          "description": "FrSky Taranis X9D"
+        }
+      ],
+      "controls": [
+        {
+          "channel": 1,
+          "type": "axis",
+          "offset": 4,
+          "signed": true
+        },
+        {
+          "channel": 2,
+          "type": "axis",
+          "offset": 6,
+          "signed": true
+        },
+        {
+          "channel": 3,
+          "type": "axis",
+          "offset": 8,
+          "signed": true
+        },
+        {
+          "channel": 4,
+          "type": "axis",
+          "offset": 10,
+          "signed": true
+
+        },
+        {
+          "channel": 5,
+          "type": "button",
+          "offset": 12,
+          "value": 2000
+        },
+        {
+          "channel": 6,
+          "type": "axis",
+          "offset": 14,
+          "signed": true
+
+        },
+        {
+          "channel": 7,
+          "type": "axis",
+          "offset": 16,
+          "signed": true
+
+        },
+        {
+          "channel": 8,
+          "type": "axis",
+          "offset": 18,
+          "signed": true
+
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi , with this pid and vid I was able to use my Taranis X9D radio as a joypad. 
However, my configuration has some problems.
I mainly focused on the first 4 channels , so the others are still to be defined . 

```
Channel1=Roll(stick1_horizontal)
Channel2=Pitch(stick1_vertical)
Channel3=Throttle(stick2_vertical)
Channel4=yaw(stick2_horizontal)
```

I can get the channels correctly on the drone , but somehow the range (which we normally have as 1100 minimum , 1900 maximum and 1515 normal) seems to be very narrow , in fact the minimum is 1502 , the maximum 1529 and the normal 1515, so for all 4 channels.